### PR TITLE
Set RSpec/Rails/InferredSpecType as false

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -247,6 +247,9 @@ RSpec/MultipleExpectations:
 RSpec/BeforeAfterAll:
   Enabled: false
 
+RSpec/Rails/InferredSpecType:
+  Enabled: false
+
 ##################### Rails ##################################
 Rails/EnvironmentVariableAccess:
   AllowReads: true


### PR DESCRIPTION
 RSpec/Rails/InferredSpecTypeをオフしました。

[Rewrites #4095](https://github.com/Catal/Rewrites/pull/4095)
参考：https://docs.rubocop.org/rubocop-rspec/cops_rspec_rails.html#rspecrailsinferredspectype