### PR TITLE
Update Rubocop Configuration: Refactor Dependencies and Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ And then execute:
 ```Gemfile
 group :development do
   gem "rubocop"
-  gem "rubocop-performance", require: false
-  gem "rubocop-rails", require: false
-  gem "rubocop-rspec", require: false
 end
 ```
 

--- a/catalcop.gemspec
+++ b/catalcop.gemspec
@@ -22,8 +22,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop"
+  spec.add_dependency "rubocop-capybara"
   spec.add_dependency "rubocop-factory_bot"
   spec.add_dependency "rubocop-performance"
   spec.add_dependency "rubocop-rails"
   spec.add_dependency "rubocop-rspec"
+  spec.add_dependency "rubocop-rspec_rails"
 end

--- a/catalcop.gemspec
+++ b/catalcop.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop"
-  spec.add_dependency "rubocop-capybara"
-  spec.add_dependency "rubocop-factory_bot"
-  spec.add_dependency "rubocop-performance"
-  spec.add_dependency "rubocop-rails"
-  spec.add_dependency "rubocop-rspec"
-  spec.add_dependency "rubocop-rspec_rails"
+  spec.add_dependency "rubocop", '~> 1.72', '>= 1.72.1'
+  spec.add_dependency "rubocop-capybara", '2.22.1'
+  spec.add_dependency "rubocop-factory_bot", '2.27.1'
+  spec.add_dependency "rubocop-performance", '1.24.0'
+  spec.add_dependency "rubocop-rails", '2.30.3'
+  spec.add_dependency "rubocop-rspec", '3.5.0'
+  spec.add_dependency "rubocop-rspec_rails", '2.31.0'
 end

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -8,8 +8,6 @@ AllCops:
     - "**/db/migrate/*.rb"
     - "**/bin/*"
     - "**/config/**/*"
-    - "**/Guardfile"
-    - "**/app/helpers/rating_helper.rb"
     - "**/node_modules/**/*"
     - "**/lib/tasks/**/*"
   DisplayCopNames: true
@@ -18,11 +16,13 @@ AllCops:
   NewCops: enable
   StyleGuideBaseURL: https://github.com/rubocop-hq/ruby-style-guide/blob/master/README.adoc
 
-require:
+plugins:
+  - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-rspec_rails
 
 ##################### Style ##################################
 


### PR DESCRIPTION
- Removed `rubocop-performance`, `rubocop-rails`, and `rubocop-rspec` from development group in Gemfile.
- Added `rubocop-capybara` and `rubocop-rspec_rails` as new dependencies in the gemspec and plugins in `rubocop.yml`.
- Removed unnecessary file exclusions from `rubocop.yml`.