### PR TITLE
Rename Naming/PredicateName to Naming/PredicatePrefix

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -177,7 +177,7 @@ Layout/LineLength:
 ##################### Naming ##################################
 
 # has_ から始まるメソッドは許可する
-Naming/PredicateName:
+Naming/PredicatePrefix:
   ForbiddenPrefixes:
     - "is_"
     - "have_"
@@ -223,7 +223,7 @@ Metrics/MethodLength:
 Metrics/BlockLength:
   Enabled: true
   Exclude:
-    - '**/spec/**/*'
+    - "**/spec/**/*"
 
 # デフォルト値を明示しないとHoundに怒られる
 Rails/FilePath:


### PR DESCRIPTION
## Overview
コップ名の変更によりNozomi, Rewrites共にRuboCopで下記のwarningが出ていたので、コップ名を変更されたものに修正しました。
RuboCop側のの変更PR：https://github.com/rubocop/rubocop/pull/14001

Nozomi https://github.com/Catal/Nozomi/actions/runs/15765925030/job/44442253595?pr=12704
```sh
Warning: The `Naming/PredicateName` cop has been renamed to `Naming/PredicatePrefix`.
(obsolete configuration found in vendor/bundle/ruby/3.3.0/bundler/gems/catalcop-feec25847f13/config/rubocop.yml, please update it)
Warning: The `Naming/PredicateName` cop has been renamed to `Naming/PredicatePrefix`.
(obsolete configuration found in .rubocop.yml, please update it)
Warning: Using `Naming/PredicateName` configuration in /home/runner/work/Nozomi/Nozomi/.rubocop.yml for `Naming/PredicatePrefix`.
```

Rewrites https://github.com/Catal/Rewrites/actions/runs/15750461404/job/44394476437?pr=7866
```sh
Warning: The `Naming/PredicateName` cop has been renamed to `Naming/PredicatePrefix`.
(obsolete configuration found in vendor/bundle/ruby/3.4.0/bundler/gems/catalcop-feec25847f13/config/rubocop.yml, please update it)
Warning: The `Naming/PredicateName` cop has been renamed to `Naming/PredicatePrefix`.
(obsolete configuration found in .rubocop.yml, please update it)
Warning: Using `Naming/PredicateName` configuration in /home/runner/work/Rewrites/Rewrites/.rubocop.yml for `Naming/PredicatePrefix`.
```

## 動作確認
Rewritesのローカルでこちらのブランチ`fix-cop-name`を指定してrubocopを実行し、warningが表示されないことを確認しました

<img width="1083" alt="スクリーンショット 2025-06-20 16 38 33" src="https://github.com/user-attachments/assets/97204967-f186-46f8-999c-316c29c29114" />
